### PR TITLE
Limit setting was not being preserved after subsequent updates

### DIFF
--- a/src/Subscription.js
+++ b/src/Subscription.js
@@ -209,14 +209,14 @@ Subscription.prototype = {
     var data = override;
     var results = this.resultSet;
     // Fetch a subset of results if the query has a limit
-    if (this.originalQuery.limit > -1) {
-      results = results.slice(0, this.originalQuery.limit);
+    if (this.originalQuery._limit > -1) {
+      results = results.slice(0, this.originalQuery._limit);
     }
     if (results[0] && !(results[0] instanceof Id)) {
       results = results.map(extractId);
     }
     if (typeof override === 'undefined') {
-      var resultSet = this.resultSet;
+      var resultSet = results;
       if (resultSet[0] && !(resultSet[0] instanceof Id)) {
         resultSet = resultSet.map(extractId);
       }

--- a/src/__tests__/Subscription-test.js
+++ b/src/__tests__/Subscription-test.js
@@ -283,4 +283,20 @@ describe('Subscription', function() {
       }
     ]);
   });
+
+  it("honors the original query 'limit'", function() {
+    var q = (new Parse.Query('Item')).limit(2);
+    var sub = new Subscription(q);
+    sub.issueQuery = jest.genMockFn();
+
+    var cb = jest.genMockFn();
+    sub.addSubscriber(cb, 'items');
+
+    sub.pushData();
+
+    sub.addResult({ id: new Id('Item', 'I1') });
+    sub.addResult({ id: new Id('Item', 'I2') });
+    sub.addResult({ id: new Id('Item', 'I3') });
+    expect(cb.mock.calls[3][1].length).toBe(2);
+  });
 });


### PR DESCRIPTION
**This was due to two reasons AFAIK:**

* `pushData` was checking existence of `query.limit` which is a function,
  instead of `query._limit` which holds the actual limit value.

* When no override is passed, subscription data was recalculated from
  the original `this.resultSet` instead of using the collection we've
  already filtered/processed

Fixes #17