### PR TITLE
return a null object state from resolveMutation when a Destroy was issued

### DIFF
--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -153,6 +153,13 @@ function destroyMutationStack(target) {
 function resolveMutation(target, payloadId, delta) {
   var stack = pendingMutations[target];
   var i;
+  if (delta.map === "DESTROY") {
+    return {
+      id: target,
+      latest: null,
+      fields: []
+    };
+  }
   for (i = 0; i < stack.length; i++) {
     if (stack[i].payloadId === payloadId) {
       delete stack[i].mutation;


### PR DESCRIPTION
This fixes #14. Not sure if this was the intended behavior, but perhaps it can help fix this bug. It makes developing tedious if you're testing deletes from a list of items.