### PR TITLE
Fixes nextProps and nextState to observe when component updates

### DIFF
--- a/src/Mixin.js
+++ b/src/Mixin.js
@@ -53,7 +53,7 @@ var Mixin = {
   componentWillUpdate: function(nextProps: any, nextState: any) {
     // only subscribe if props or state changed
     if (nextProps !== this.props || nextState !== this.state) {
-      this._subscribe();
+      this._subscribe(nextProps, nextState);
     }
   },
 


### PR DESCRIPTION
When componentWillUpdate is triggered, the observe function gets called and the nextProps and nextState gets dropped even if changed
