### PR TITLE
Fix: Crash against `null` store values

### DIFF
--- a/src/__tests__/ObjectStore-test.js
+++ b/src/__tests__/ObjectStore-test.js
@@ -394,6 +394,24 @@ describe('Object storage', function() {
     });
   });
 
+  it('handles `null` values', function() {
+    var Item = Parse.Object.extend('Item');
+    var results = [
+      new Item({
+        id: 'I1',
+        value: null
+      })
+    ];
+    var query = new Parse.Query(Item);
+    ObjectStore.storeQueryResults(results, query);
+    expect(ObjectStore.deepFetch(new Id('Item', 'I1'))).toEqual({
+      id: new Id('Item', 'I1'),
+      className: 'Item',
+      objectId: 'I1',
+      value: null
+    });
+  });
+
   it('can fetch multiple objects as shallow copies', function() {
     var Item = Parse.Object.extend('Item');
     var items = [


### PR DESCRIPTION
Currently if a store contains a `null` object, the fetch crashes with
this error:
```
  Uncaught TypeError: Cannot read property '__type' of `null`
```
This is because the current implemenation checks to see if the
`sourceVal` is an 'object' type. `typeof null == 'object'` returns
truthy. However `null.__type` is not valid.