### PR TITLE
Fix: `QueryTools.stringify` fails on `null` value

### DIFF
--- a/lib/QueryTools.js
+++ b/lib/QueryTools.js
@@ -63,6 +63,9 @@ function stringify(object) {
     copy.sort();
     return '[' + copy.join(',') + ']';
   }
+  if (null === object) {
+    return 'null';
+  }
   var sections = [];
   var keys = Object.keys(object);
   keys.sort();

--- a/src/__tests__/QueryTools-test.js
+++ b/src/__tests__/QueryTools-test.js
@@ -14,6 +14,7 @@ var QueryTools = require('../QueryTools');
 var queryHash = QueryTools.queryHash;
 var keysFromHash = QueryTools.keysFromHash;
 var matchesQuery = QueryTools.matchesQuery;
+var stringify = QueryTools.stringify;
 
 var Item = Parse.Object.extend('Item');
 
@@ -381,5 +382,13 @@ describe('matchesQuery', function() {
     expect(matchesQuery(player, q)).toBe(true);
     q.contains('name', 'h \\Q or');
     expect(matchesQuery(player, q)).toBe(false);
+  });
+});
+
+describe('stringify', function() {
+  it('handles null values', function() {
+    var value = null;
+
+    expect(stringify(value)).toBe("null");
   });
 });


### PR DESCRIPTION
It is possible for Parse to have a valid `null` value for a field.
`JSON.stringify` converts a `null` value to "null". This PR proposes a
fix to emulate that behavior in the `QueryTools` lib.

* [ ] Allow stringification of `null` values
* [ ] Ready for review