### PR TITLE
Supply data for all pointers at same depth in nested queries

### DIFF
--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -365,13 +365,14 @@ function deepFetch(id: Id, seen?: Array<string>) {
   }
   var source = store[id].data;
   var obj = {};
+  var seenChildren = [];
   for (var attr in source) {
     var sourceVal = source[attr];
     if ( sourceVal && typeof sourceVal === 'object' && sourceVal.__type === 'Pointer') {
       var childId = new Id(sourceVal.className, sourceVal.objectId);
       if (seen.indexOf(childId.toString()) < 0 && store[childId]) {
-        seen = seen.concat([childId.toString()]);
-        sourceVal = deepFetch(childId, seen);
+        seenChildren = seenChildren.concat([childId.toString()]);
+        sourceVal = deepFetch(childId, seen.concat(seenChildren));
       }
     }
     obj[attr] = sourceVal;

--- a/src/__tests__/ObjectStore-test.js
+++ b/src/__tests__/ObjectStore-test.js
@@ -376,6 +376,40 @@ describe('Object storage', function() {
     });
   });
 
+  it('supplies data for all pointers that exist at the same depth', function() {
+    var Item = Parse.Object.extend('Item');
+    var child = new Item({
+      id: 'I2',
+      value: 12
+    });
+    var parent = new Item({
+      id: 'I1',
+      value: 11,
+      childA: child,
+      childB: child
+    });
+    query = new Parse.Query(Item).include('childA,childB');
+    ObjectStore.storeQueryResults([parent, child], query);
+    expect(ObjectStore.deepFetch(new Id('Item', 'I1'), [])).toEqual({
+      id: new Id('Item', 'I1'),
+      className: 'Item',
+      objectId: 'I1',
+      value: 11,
+      childA: {
+        id: new Id('Item', 'I2'),
+        className: 'Item',
+        objectId: 'I2',
+        value: 12
+      },
+      childB: {
+        id: new Id('Item', 'I2'),
+        className: 'Item',
+        objectId: 'I2',
+        value: 12
+      }
+    });
+  });
+
   it('handles empty pointers when queries include multiple layers', function() {
     var Item = Parse.Object.extend('Item');
     var results = [


### PR DESCRIPTION
// Fetch all nodes, and the data for childA and childB
new Parse.Query('Node').include('childA,childB')

Currently, if an object's childA and childB fields point to the same object, only the data for childA is populated, and childB is a pointer. The fix supplies data for all pointers that exist at the same depth of a tree. Basically, rather than updating the seen state in-place, it maintains a new seen state (seenChildren) that isn't used at the current layer, but is passed to the next deepFetch call.