### PR TITLE
Support for batch mutations

### DIFF
--- a/docs/DataMutations.md
+++ b/docs/DataMutations.md
@@ -83,3 +83,20 @@ The `dispatch()` call returns a `Parse.Promise`, so that you can respond when
 server request succeeds or fails. In case of failure, you may want to update
 the state of your application to display a message to the user, and possibly
 give them a click-to-retry option.
+
+Note: the above will send three individual requests to the server. Often it is
+desirable to group multiple mutation call into one batch request:
+
+```js
+var batch = new ParseReact.Mutation.Batch();
+creator.dispatch({ batch: batch });
+creator.dispatch({ batch: batch });
+creator.dispatch({ batch: batch });
+batch.dispatch();
+```
+
+The promises returned by the individual `dispatch()` calls of the mutations
+will continue to work as usual, but won't be resolved until the batch request
+has been completed. The batch's `dispatch()` call also returns a
+`Parse.Promise()` to inform the caller of the success or failure of the overall
+batch request.

--- a/docs/api/Mutation.md
+++ b/docs/api/Mutation.md
@@ -13,10 +13,12 @@ is updated, the new version will be pushed to all subscribed components.
 when the server request completes. If an error occurs, the promise is rejected.
 
 - `options` (optional): A plain JavaScript object of key/value pairs to
-configure the dispatch. At this point, only one option is supported:
+configure the dispatch.
   - `waitForServer` (default: `false`): If set to true, components won't update
   optimistically, and will wait for confirmation that the operation was
   successful before updating.
+  - `batch`: Pass a `ParseReact.Mutation.Batch` instance to perform the mutation
+  as part of that batch rather than individually.
 
 ## Mutation Generators
 

--- a/src/Mutation.js
+++ b/src/Mutation.js
@@ -25,6 +25,7 @@
 
 var Delta = require('./Delta');
 var Id = require('./Id');
+var MutationBatch = require('./MutationBatch');
 var Parse = require('./StubParse');
 var UpdateChannel = require('./UpdateChannel');
 
@@ -190,6 +191,7 @@ class Mutation {
 
 module.exports = {
   Mutation: Mutation,
+  Batch: MutationBatch,
   // Basic Mutations
   Create: function(className: string, data: any): Mutation {
     data = data || {};

--- a/src/MutationBatch.js
+++ b/src/MutationBatch.js
@@ -48,7 +48,8 @@ class MutationBatch {
 
   addRequest(options: ParseRequestOptions): Parse.Promise {
     if (this.getNumberOfRequests() === MutationBatch.maxBatchSize) {
-      throw new Error('Cannot batch more than 50 requests at a time');
+      throw new Error('Cannot batch more than ' + MutationBatch.maxBatchSize +
+        ' requests at a time.');
     }
     var promise = options.__promise = new Parse.Promise();
     this._requests.push(options);

--- a/src/MutationBatch.js
+++ b/src/MutationBatch.js
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2015, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ *  use, copy, modify, and distribute this software in source code or binary
+ *  form for use in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  @flow
+ */
+
+'use strict';
+
+var Parse = require('./StubParse');
+
+type ParseRequestOptions = {
+  method: string;
+  route: string;
+  className: string;
+};
+
+class MutationBatch {
+  static maxBatchSize: number;
+
+  _requests: Array<ParseRequestOptions>;
+  addRequest: (options: ParseRequestOptions) => Parse.Promise;
+
+  constructor() {
+    this._requests = [];
+    this.addRequest = this.addRequest.bind(this);
+  }
+
+  getNumberOfRequests(): number {
+    return this._requests.length;
+  }
+
+  addRequest(options: ParseRequestOptions): Parse.Promise {
+    if (this.getNumberOfRequests() === MutationBatch.maxBatchSize) {
+      throw new Error('Cannot batch more than 50 requests at a time');
+    }
+    var promise = options.__promise = new Parse.Promise();
+    this._requests.push(options);
+    return promise;
+  }
+
+  dispatch(): Parse.Promise {
+    var requests = this._requests.map(function (req) {
+      var path = '/1/' + req.route;
+      if (req.className) {
+        path += '/' + req.className;
+      }
+      if (req.objectId) {
+        path += '/' + req.objectId
+      }
+      return {
+        method: req.method,
+        path: path,
+        body: req.data,
+      };
+    });
+    var batchRequest = {
+      method: 'POST',
+      route: 'batch',
+      data: {requests: requests},
+    };
+    var self = this;
+    return Parse._request(batchRequest).then(function(response) {
+      self._requests.forEach(function (req, i) {
+        var result = response[i];
+        if (result.success) {
+          req.__promise.resolve(result.success);
+        } else if (result.error) {
+          req.__promise.reject(result.error);
+        }
+      });
+    }, function(error) {
+      self._requests.forEach(function (req, i) {
+        req.__promise.reject(error);
+      });
+      return Parse.Promise.error(error);
+    });
+  }
+}
+MutationBatch.maxBatchSize = 50;
+
+module.exports = MutationBatch;

--- a/src/MutationExecutor.js
+++ b/src/MutationExecutor.js
@@ -26,6 +26,15 @@
 var Id = require('./Id');
 var Parse = require('./StubParse');
 
+type ParseRequestOptions = {
+  method: string;
+  route: string;
+  className: string;
+};
+
+import type * as MutationBatch from './MutationBatch';
+
+
 var toString = Object.prototype.toString;
 // Special version of Parse._encode to handle our unique representations of
 // pointers
@@ -88,7 +97,7 @@ function encode(data, seen?) {
   return data;
 }
 
-function request(options) {
+function sendRequest(options: ParseRequestOptions): Parse.Promise {
   return Parse._request(options).then(function(result) {
     if (result.createdAt) {
       result.createdAt = new Date(result.createdAt);
@@ -100,10 +109,16 @@ function request(options) {
   });
 }
 
-function execute(action: string, target: Id|string, data: any) {
+function execute(
+  action: string,
+  target: Id|string,
+  data: any,
+  batch: ?MutationBatch
+): Parse.Promise {
   var className = (typeof target === 'string') ? target : target.className;
   var objectId = (typeof target === 'string') ? '' : target.objectId;
   var payload;
+  var request = batch ? batch.addRequest : sendRequest;
   switch (action) {
     case 'CREATE':
       return request({

--- a/src/UpdateChannel.js
+++ b/src/UpdateChannel.js
@@ -89,7 +89,8 @@ export function issueMutation(mutation: Mutation, options: { [key: string]: bool
   MutationExecutor.execute(
     mutation.action,
     mutation.target,
-    mutation.data
+    mutation.data,
+    options.batch
   ).then(function(result) {
     var changes;
     var subscribers = ObjectStore.fetchSubscribers(target);

--- a/src/__tests__/MutationBatch-test.js
+++ b/src/__tests__/MutationBatch-test.js
@@ -1,0 +1,194 @@
+'use strict';
+
+jest.dontMock('parse');
+jest.dontMock('../MutationBatch');
+jest.dontMock('../StubParse');
+
+var MutationBatch = require('../MutationBatch');
+var Parse = require('parse').Parse;
+Parse.initialize('testid', 'testkey');
+
+var testXHR = function(urlTest, bodyTest, status, response) {
+  var XHR = function() { };
+  XHR.prototype = {
+    open: function(method, url) {
+      urlTest(method, url);
+    },
+    setRequestHeader: function() { },
+    send: function(body) {
+      bodyTest(body);
+      this.status = status;
+      this.responseText = JSON.stringify(response || {});
+      this.readyState = 4;
+      this.onreadystatechange();
+    }
+  };
+  return XHR;
+};
+
+describe('MutationBatch', function() {
+
+  it('reports number of requests being batched', function() {
+    var batch = new MutationBatch();
+    expect(batch.getNumberOfRequests()).toBe(0);
+    batch.addRequest({
+      method: 'DELETE',
+      route: 'classes',
+      className: 'MadeUpClassName',
+      objectId: 'randomId',
+    });
+    expect(batch.getNumberOfRequests()).toBe(1);
+  });
+
+  it('accepts a maximum number of requests', function() {
+    var batch = new MutationBatch();
+    for (var i = 0; i < MutationBatch.maxBatchSize; i++) {
+      batch.addRequest({
+        method: 'DELETE',
+        route: 'classes',
+        className: 'MadeUpClassName',
+        objectId: 'randomId_' + i,
+      });
+    }
+    expect(function() {
+      batch.addRequest({
+        method: 'DELETE',
+        route: 'classes',
+        className: 'MadeUpClassName',
+        objectId: 'onetoomany',
+      });
+    }).toThrow();
+  });
+
+  it('dispatches requests in one batch and resolves promises', function() {
+    var batch = new MutationBatch();
+    var firstPromise = batch.addRequest({
+      method: 'DELETE',
+      route: 'classes',
+      className: 'MadeUpClassName',
+      objectId: 'randomId',
+    });
+    var secondPromise = batch.addRequest({
+      method: 'CREATE',
+      route: 'classes',
+      className: 'MadeUpClassName',
+      data: {some: 'fields', and: 'stuff'},
+    });
+    var thirdPromise = batch.addRequest({
+      method: 'SET',
+      route: 'classes',
+      className: 'MadeUpClassName',
+      objectId: 'non_existent',
+      data: {cant: 'touch', this_: 'duuh duhduhduh dummm duh duh'},
+    });
+
+    var firstPromiseResult = null;
+    var secondPromiseResult = null;
+    var thirdPromiseResult = null;
+    var thirdPromiseError = null;
+    var expectedFirstResult = {first: 'result'};
+    var expectedSecondResult = {second: 'result'};
+    var expectedThirdError = {why: 'did', you: 'touch this?'};
+    firstPromise.then(
+      function(result) { firstPromiseResult = result; },
+      function(error) { throw error; }
+    );
+    secondPromise.then(
+      function(result) { secondPromiseResult = result; },
+      function(error) { throw error; }
+    );
+    thirdPromise.then(
+      function(result) { thirdPromiseResult = result; },
+      function(error) { thirdPromiseError = error; }
+    );
+
+    Parse.XMLHttpRequest = testXHR(function(method, url) {
+      expect(method).toBe('POST');
+      expect(url).toBe('https://api.parse.com/1/batch');
+    }, function(body) {
+      var requests = JSON.parse(body).requests;
+      expect(requests).toEqual({
+        0: {
+          method: 'DELETE',
+          path: '/1/classes/MadeUpClassName/randomId',
+        },
+        1: {
+          method: 'CREATE',
+          path: '/1/classes/MadeUpClassName',
+          body: {
+            some: 'fields',
+            and: 'stuff',
+          },
+        },
+        2: {
+          method: 'SET',
+          path: '/1/classes/MadeUpClassName/non_existent',
+          body: {
+            cant: 'touch',
+            this_: 'duuh duhduhduh dummm duh duh',
+          },
+        },
+      });
+    }, 200, [
+      {success: expectedFirstResult},
+      {success: expectedSecondResult},
+      {error: expectedThirdError},
+    ]);
+    var batchPromiseResolved = false;
+    batch.dispatch().then(function() { batchPromiseResolved = true; });
+
+    expect(firstPromiseResult).toEqual(expectedFirstResult);
+    expect(secondPromiseResult).toEqual(expectedSecondResult);
+    expect(thirdPromiseResult).toBe(null);
+    expect(thirdPromiseError).toEqual(expectedThirdError);
+    expect(batchPromiseResolved).toBe(true);
+  });
+
+  it('resolves promises even when request fails', function() {
+    Parse.XMLHttpRequest = testXHR(
+      function() {},
+      function() {},
+      418
+    );
+
+    var batch = new MutationBatch();
+    var firstPromise = batch.addRequest({
+      method: 'DELETE',
+      route: 'classes',
+      className: 'MadeUpClassName',
+      objectId: 'randomId',
+    });
+    var secondPromise = batch.addRequest({
+      method: 'CREATE',
+      route: 'classes',
+      className: 'MadeUpClassName',
+      data: {some: 'fields', and: 'stuff'},
+    });
+
+    var firstPromiseResult = null;
+    var firstPromiseError = null;
+    var secondPromiseResult = null;
+    var secondPromiseError = null;
+    firstPromise.then(
+      function(result) { firstPromiseResult = result; },
+      function(error) { firstPromiseError = error; }
+    );
+    secondPromise.then(
+      function(result) { secondPromiseResult = result; },
+      function(error) { secondPromiseError = error; }
+    );
+    var batchPromiseSuccess = false;
+    var batchPromiseError = null;
+    batch.dispatch().then(
+      function() { batchPromiseSuccess = true; },
+      function(error) { batchPromiseError = error; }
+    );
+
+    expect(firstPromiseResult).toBe(null);
+    expect(secondPromiseResult).toBe(null);
+    expect(firstPromiseError).toBe(secondPromiseError);
+    expect(batchPromiseError).toBe(firstPromiseError);
+    expect(batchPromiseSuccess).toBe(false);
+  });
+
+});


### PR DESCRIPTION
The API I'm proposing and have implemented here would let you batch mutations as follows:

```js
var batch = new ParseReact.Mutation.Batch();
// First delete old entries.
old_entries.forEach(
  (entry) => ParseReact.Mutation.Destroy(entry.id).dispatch({batch})
);
// Now let's create a new entry:
ParseReact.Mutation.Create('Entry', {...}).dispatch({batch}).then((response) => {
  ... // do something with response here
});
// Finally save it all to the server in one request.
batch.dispatch();
```

The advantage of making the batch an option of `dispatch()` is that each individual mutation retains its characteristics entirely -- including the optimistic update behaviour -- it's just that the underlying request to perform the mutation may take, well, much longer :). `ParseReact.Mutation.Batch` will still tie individual request results back to each mutation, so to consumers like the `ObjectStore`, everything should look and feel the same.