### PR TITLE
Provide a StubReact module to bridge 'react' vs 'react-native' difference

### DIFF
--- a/lib/ParseComponent.js
+++ b/lib/ParseComponent.js
@@ -34,8 +34,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var React = require('react');
-
+var React = require('./StubReact');
 var Parse = require('./StubParse');
 var ParsePatches = require('./ParsePatches');
 var warning = require('./warning');

--- a/lib/StubReact.js
+++ b/lib/StubReact.js
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2015, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ *  use, copy, modify, and distribute this software in source code or binary
+ *  form for use in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ */
+
+'use strict';
+
+if (typeof React === 'undefined') {
+  if (typeof require === 'function') {
+    try {
+      module.exports = require('react');
+    } catch (e) {
+      try {
+        module.exports = require('react-native');
+      } catch (e) {
+        throw new Error('Failed to require react module. You need React ' + 'or React Native to use Parse + React');
+      }
+    }
+  } else {
+    throw new Error('Cannot initialize Parse + React: Parse is not defined.');
+  }
+} else {
+  module.exports = React;
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "LICENSE",
     "README.md"
   ],
+  "browser": {
+    "react-native": false
+  },
   "devDependencies": {
     "babel-jest": "~5.0.0",
     "babelify": "^6.0.2",

--- a/src/ParseComponent.js
+++ b/src/ParseComponent.js
@@ -22,8 +22,7 @@
 
 'use strict';
 
-var React = require('react');
-
+var React = require('./StubReact');
 var Parse = require('./StubParse');
 var ParsePatches = require('./ParsePatches');
 var warning = require('./warning');

--- a/src/StubReact.js
+++ b/src/StubReact.js
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2015, Parse, LLC. All rights reserved.
+ *
+ *  You are hereby granted a non-exclusive, worldwide, royalty-free license to
+ *  use, copy, modify, and distribute this software in source code or binary
+ *  form for use in connection with the web services and APIs provided by Parse.
+ *
+ *  As with any software that integrates with the Parse platform, your use of
+ *  this software is subject to the Parse Terms of Service
+ *  [https://www.parse.com/about/terms]. This copyright notice shall be
+ *  included in all copies or substantial portions of the software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ */
+
+'use strict';
+
+if (typeof React === 'undefined') {
+  if (typeof require === 'function') {
+    // Trick the React Native packager so that it won't try to bundle
+    // the 'react' package when it's not available.
+    var req = require;
+    try {
+      module.exports = req('react');
+    } catch (e) {
+      try {
+        module.exports = req('react-native');
+      } catch (e) {
+        throw new Error('Failed to require react module. You need React ' +
+                        'or React Native to use Parse + React');
+      }
+    }
+  } else {
+    throw new Error('Cannot initialize Parse + React: Parse is not defined.');
+  }
+} else {
+  module.exports = React;
+}


### PR DESCRIPTION
Doing this will let us use `ParseComponent` in React Native apps.