### PR TITLE
Clean-ups and refactorings

### DIFF
--- a/src/MutationExecutor.js
+++ b/src/MutationExecutor.js
@@ -26,10 +26,12 @@
 var Id = require('./Id');
 var Parse = require('./StubParse');
 
-type ParseRequestOptions = {
+export type ParseRequestOptions = {
   method: string;
   route: string;
   className: string;
+  data?: any;
+  objectId?: string;
 };
 
 import type * as MutationBatch from './MutationBatch';


### PR DESCRIPTION
- `Subscription.pushData()` was handling both the success and error cases. The code actually run in both cases was nearly 100% different, making it hard to reason about what was actually happening. So I've factored out the error case into a separate `Subscription.pushError()` method.
- `MutationBatch` was causing a bunch of flow warnings (my bad), mostly due to some unclean design.
- Improved Flow declarations and ES6-ness thrown in for free.