### PR TITLE
Refactor and improve Flow typing

### DIFF
--- a/src/Delta.js
+++ b/src/Delta.js
@@ -25,6 +25,8 @@
 
 var Id = require('./Id');
 
+import type { FlattenedObjectData } from './ObjectStore';
+
 /**
  * A Delta represents a change that has been verified by the server, but has
  * not yet been merged into the "Last True State" (typically because some
@@ -39,10 +41,10 @@ class Delta {
   destroy: ?boolean;
 
   constructor(
-      id: Id,
-      data: { [key: string]: any },
-      options?: { [key: string]: boolean }
-    ) {
+    id: Id,
+    data: FlattenedObjectData,
+    options?: { [key: string]: boolean }
+  ) {
     if (!(id instanceof Id)) {
       throw new TypeError('Cannot create a Delta with an invalid target Id');
     }

--- a/src/Delta.js
+++ b/src/Delta.js
@@ -80,8 +80,6 @@ class Delta {
     for (var attr in source.map) {
       this.map[attr] = source.map[attr];
     }
-
-    return this;
   }
 }
 

--- a/src/MutationBatch.js
+++ b/src/MutationBatch.js
@@ -25,7 +25,7 @@
 
 var Parse = require('./StubParse');
 
-import type ParseRequestOptions from './MutationExecutor';
+import type { ParseRequestOptions } from './MutationExecutor';
 
 class MutationBatch {
   static maxBatchSize: number;

--- a/src/MutationExecutor.js
+++ b/src/MutationExecutor.js
@@ -41,7 +41,7 @@ import type * as MutationBatch from './MutationBatch';
 var toString = Object.prototype.toString;
 // Special version of Parse._encode to handle our unique representations of
 // pointers
-function encode(data, seen?) {
+function encode(data: any, seen?: Array<any>): any {
   if (!seen) {
     seen = [];
   }
@@ -237,12 +237,7 @@ function execute(
   throw new TypeError('Invalid Mutation action: ' + mutation.action);
 }
 
-var MutationExecutor: any = {
-  execute: execute,
-};
-
+module.exports.execute = execute;
 if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
-  MutationExecutor.encode = encode;
+  module.exports.encode = encode;
 }
-
-module.exports = MutationExecutor;

--- a/src/MutationExecutor.js
+++ b/src/MutationExecutor.js
@@ -34,6 +34,7 @@ export type ParseRequestOptions = {
   objectId?: string;
 };
 
+import type { Mutation } from './Mutation';
 import type * as MutationBatch from './MutationBatch';
 
 
@@ -112,16 +113,16 @@ function sendRequest(options: ParseRequestOptions): Parse.Promise {
 }
 
 function execute(
-  action: string,
-  target: Id|string,
-  data: any,
+  mutation: Mutation,
   batch: ?MutationBatch
 ): Parse.Promise {
+  var target = mutation.target;
+  var data = mutation.data;
   var className = (typeof target === 'string') ? target : target.className;
   var objectId = (typeof target === 'string') ? '' : target.objectId;
   var payload;
   var request = batch ? batch.addRequest : sendRequest;
-  switch (action) {
+  switch (mutation.action) {
     case 'CREATE':
       return request({
         method: 'POST',
@@ -233,7 +234,7 @@ function execute(
         data: payload
       });
   }
-  throw new TypeError('Invalid Mutation action: ' + action);
+  throw new TypeError('Invalid Mutation action: ' + mutation.action);
 }
 
 var MutationExecutor: any = {

--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -365,7 +365,7 @@ function getDataForIds(ids: Id | Array<Id>): Array<FlattenedObjectData> {
 /**
  * Fetch objects from the store, converting pointers to objects where possible
  */
-function deepFetch(id: Id, seen?: Array<string>) {
+function deepFetch(id: Id, seen?: Array<string>): ?FlattenedObjectData {
   if (!store[id]) {
     return null;
   }
@@ -392,7 +392,7 @@ function deepFetch(id: Id, seen?: Array<string>) {
 /**
  * Calculate the result of applying all Mutations to an object.
  */
-function getLatest(id: Id) {
+function getLatest(id: Id): ?FlattenedObjectData {
   if (pendingMutations[id] && pendingMutations[id].length > 0) {
     var base = {};
     var mutation;
@@ -431,26 +431,22 @@ function getLatest(id: Id) {
   return store[id] ? deepFetch(id) : null;
 }
 
-var ObjectStore: { [key: string]: any } = {
-  storeObject: storeObject,
-  removeObject: removeObject,
-  addSubscriber: addSubscriber,
-  removeSubscriber: removeSubscriber,
-  fetchSubscribers: fetchSubscribers,
-  stackMutation: stackMutation,
-  destroyMutationStack: destroyMutationStack,
-  resolveMutation: resolveMutation,
-  commitDelta: commitDelta,
-  storeQueryResults: storeQueryResults,
-  getDataForIds: getDataForIds,
-  deepFetch: deepFetch,
-  getLatest: getLatest
-};
+module.exports.storeObject = storeObject;
+module.exports.removeObject = removeObject;
+module.exports.addSubscriber = addSubscriber;
+module.exports.removeSubscriber = removeSubscriber;
+module.exports.fetchSubscribers = fetchSubscribers;
+module.exports.stackMutation = stackMutation;
+module.exports.destroyMutationStack = destroyMutationStack;
+module.exports.resolveMutation = resolveMutation;
+module.exports.commitDelta = commitDelta;
+module.exports.storeQueryResults = storeQueryResults;
+module.exports.getDataForIds = getDataForIds;
+module.exports.deepFetch = deepFetch;
+module.exports.getLatest = getLatest;
 
 if (typeof process !== 'undefined' && process.env.NODE_ENV === 'test') {
   // Expose the raw storage
-  ObjectStore._rawStore = store;
-  ObjectStore._rawMutations = pendingMutations;
+  module.exports._rawStore = store;
+  module.exports._rawMutations = pendingMutations;
 }
-
-module.exports = ObjectStore;

--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -23,12 +23,18 @@
 
 'use strict';
 
-import type * as Delta from './Delta';
-import type { Mutation } from './Mutation';
-
 var flatten = require('./flatten');
 var Id = require('./Id');
 var queryHash = require('./QueryTools').queryHash;
+
+import type * as Delta from './Delta';
+import type { Mutation } from './Mutation';
+
+export type OrderingInfo = { [key: string]: any };
+export type IdWithOrderingInfo = {
+  id: Id;
+  ordering: OrderingInfo;
+};
 
 /**
  * ObjectStore is a local cache for Parse Objects. It stores the last known
@@ -274,8 +280,10 @@ function commitDelta(delta: Delta):
  * Returns an array of object Ids, or an array of maps containing Ids and query-
  * specific ordering information.
  */
-function storeQueryResults(results: Array<ParseObject> | ParseObject, query: ParseQuery):
-    Array<Id | { id: Id; ordering: any }> {
+function storeQueryResults(
+  results: Array<ParseObject> | ParseObject,
+  query: ParseQuery
+): Array<Id | IdWithOrderingInfo> {
   var hash = queryHash(query);
   if (!Array.isArray(results)) {
     results = [results];

--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -36,6 +36,11 @@ export type IdWithOrderingInfo = {
   ordering: OrderingInfo;
 };
 export type FlattenedObjectData = { [attr: string]: any };
+export type ObjectChangeDescriptor = {
+  id: Id;
+  latest: any;  // TODO: this should really be FlattenedObjectData
+  fields?: Array<string>;
+};
 
 /**
  * ObjectStore is a local cache for Parse Objects. It stores the last known
@@ -175,7 +180,11 @@ function destroyMutationStack(target: Id) {
  * Returns the latest object state and an array of keys that changed, or null
  * in the case of a Destroy
  */
-function resolveMutation(target: Id, payloadId: number, delta: Delta): { id: Id; latest: any; fields?: Array<string> } {
+function resolveMutation(
+  target: Id,
+  payloadId: number,
+  delta: Delta
+): ObjectChangeDescriptor {
   var stack = pendingMutations[target];
   var i;
   for (i = 0; i < stack.length; i++) {
@@ -226,8 +235,7 @@ function resolveMutation(target: Id, payloadId: number, delta: Delta): { id: Id;
  * Returns the latest object state and an array of keys that changed, or null
  * in the case of a Destroy
  */
-function commitDelta(delta: Delta):
-    { id: Id; latest: any; fields?: Array<string> } {
+function commitDelta(delta: Delta): ObjectChangeDescriptor {
   var id = delta.id;
   if (delta.destroy) {
     if (store[id]) {

--- a/src/ObjectStore.js
+++ b/src/ObjectStore.js
@@ -35,6 +35,7 @@ export type IdWithOrderingInfo = {
   id: Id;
   ordering: OrderingInfo;
 };
+export type FlattenedObjectData = { [attr: string]: any };
 
 /**
  * ObjectStore is a local cache for Parse Objects. It stores the last known
@@ -48,7 +49,7 @@ export type IdWithOrderingInfo = {
 // queries subscribed to the object.
 var store: {
   [id: Id]: {
-    data: { [attr: string]: any };
+    data: FlattenedObjectData;
     queries: { [hash: string]: boolean }
   }
 } = {};
@@ -72,7 +73,7 @@ var mutationCount = 0;
  * storeObject: takes a flattened object as the single argument, and places it
  * in the Store, indexed by its Id.
  */
-function storeObject(data: { [attr: string]: any }): Id {
+function storeObject(data: FlattenedObjectData): Id {
   if (!(data.id instanceof Id)) {
     throw new Error('Cannot store an object without an Id');
   }
@@ -344,7 +345,7 @@ function storeQueryResults(
  * Given a list of object Ids, fetches the latest data for each object
  * and returns the results as an array of shallow copies.
  */
-function getDataForIds(ids: Id | Array<Id>): Array<any> {
+function getDataForIds(ids: Id | Array<Id>): Array<FlattenedObjectData> {
   if (!Array.isArray(ids)) {
     ids = [ids];
   }
@@ -376,7 +377,7 @@ function deepFetch(id: Id, seen?: Array<string>) {
   var seenChildren = [];
   for (var attr in source) {
     var sourceVal = source[attr];
-    if ( sourceVal && typeof sourceVal === 'object' && sourceVal.__type === 'Pointer') {
+    if (sourceVal && typeof sourceVal === 'object' && sourceVal.__type === 'Pointer') {
       var childId = new Id(sourceVal.className, sourceVal.objectId);
       if (seen.indexOf(childId.toString()) < 0 && store[childId]) {
         seenChildren = seenChildren.concat([childId.toString()]);

--- a/src/QueryTools.js
+++ b/src/QueryTools.js
@@ -27,6 +27,8 @@ var equalObjects = require('./equalObjects');
 var Id = require('./Id');
 var Parse = require('./StubParse');
 
+import type { FlattenedObjectData } from './ObjectStore';
+
 /**
  * Query Hashes are deterministic hashes for Parse Queries.
  * Any two queries that have the same set of constraints will produce the same
@@ -145,8 +147,9 @@ function keysFromHash(hash: string):
  * queries, we can avoid building a full-blown query tool.
  */
 function matchesQuery(
-    object: { [key: string]: any },
-    query: ParseQuery | { [key: string]: any }): boolean {
+  object: FlattenedObjectData,
+  query: ParseQuery | { [key: string]: any }
+): boolean {
   if (query instanceof Parse.Query) {
     var className =
       (object.id instanceof Id) ? object.id.className : object.className;

--- a/src/UpdateChannel.js
+++ b/src/UpdateChannel.js
@@ -111,8 +111,8 @@ export function issueMutation(mutation: Mutation, options: { [key: string]: bool
       if (mutation.action === 'CREATE') {
         // Make sure the local object is removed from any result sets
         for (var i = 0; i < subscribers.length; i++) {
-          var subscriber = SubscriptionManager.getSubscription(subscribers[i]);
-          subscriber.removeResult(target);
+          var subscription = SubscriptionManager.getSubscription(subscribers[i]);
+          subscription.removeResult(target);
         }
         ObjectStore.destroyMutationStack(target);
       } else {
@@ -143,12 +143,12 @@ function pushUpdates(subscribers: Array<string>, changes: { id: Id; latest: any;
   if (changes.latest === null) {
     // Pushing a Destroy action. Remove it from all current subscribers
     for (i = 0; i < subscribers.length; i++) {
-      subscriber = SubscriptionManager.getSubscription(subscribers[i]);
-      if (!subscriber) {
+      subscription = SubscriptionManager.getSubscription(subscribers[i]);
+      if (!subscription) {
         throw new Error('Object is attached to a nonexistent subscription');
       }
-      subscriber.removeResult(changes.id);
-    }
+      subscription.removeResult(changes.id);
+    };
     return null;
   }
   // For all current subscribers, check if the object still matches the query.
@@ -156,19 +156,19 @@ function pushUpdates(subscribers: Array<string>, changes: { id: Id; latest: any;
   var visited = {};
   for (i = 0; i < subscribers.length; i++) {
     visited[subscribers[i]] = true;
-    subscriber = SubscriptionManager.getSubscription(subscribers[i]);
-    if (QueryTools.matchesQuery(changes.latest, subscriber.originalQuery)) {
+    subscription = SubscriptionManager.getSubscription(subscribers[i]);
+    if (QueryTools.matchesQuery(changes.latest, subscription.originalQuery)) {
       if (changes.id.toString() !== changes.latest.id.toString()) {
         // It's a Create method
-        subscriber.removeResult(changes.id, true);
+        subscription.removeResult(changes.id, true);
         ObjectStore.removeSubscriber(changes.id, subscribers[i]);
-        subscriber.addResult(changes.latest);
+        subscription.addResult(changes.latest);
         ObjectStore.addSubscriber(changes.latest.id, subscribers[i]);
       } else {
-        subscriber.pushData();
+        subscription.pushData();
       }
     } else {
-      subscriber.removeResult(changes.id);
+      subscription.removeResult(changes.id);
       ObjectStore.removeSubscriber(changes.id, subscribers[i]);
     }
   }
@@ -180,9 +180,9 @@ function pushUpdates(subscribers: Array<string>, changes: { id: Id; latest: any;
     if (visited[potentials[i]]) {
       continue;
     }
-    subscriber = SubscriptionManager.getSubscription(potentials[i]);
-    if (QueryTools.matchesQuery(changes.latest, subscriber.originalQuery)) {
-      subscriber.addResult(changes.latest);
+    subscription = SubscriptionManager.getSubscription(potentials[i]);
+    if (QueryTools.matchesQuery(changes.latest, subscription.originalQuery)) {
+      subscription.addResult(changes.latest);
       ObjectStore.addSubscriber(changes.latest.id, potentials[i]);
     }
   }

--- a/src/UpdateChannel.js
+++ b/src/UpdateChannel.js
@@ -178,7 +178,3 @@ function pushUpdates(subscribers: Array<string>, changes: { id: Id; latest: any;
   }
   return changes.latest;
 }
-
-module.exports = {
-  issueMutation: issueMutation
-};

--- a/src/UpdateChannel.js
+++ b/src/UpdateChannel.js
@@ -123,7 +123,13 @@ function performOptimisticMutation(
  * fetch a list of potential new subscribers using the changed fields, and add
  * the object to the result sets of any queries that now match.
  */
-function pushUpdates(subscribers: Array<string>, changes: { id: Id; latest: any; fields?: Array<string> }) {
+function pushUpdates(
+  subscribers: Array<string>,
+  // TODO: we really want to use the ObjectChangeDescriptor type alias from
+  // ObjectStore here, but importing it will cause a bunch of additional Flow
+  // checks to happen that we're not ready for yet.
+  changes: { id: Id; latest: any; fields?: Array<string> }
+) {
   var i;
   if (changes.latest === null) {
     // Pushing a Destroy action. Remove it from all current subscribers

--- a/src/__tests__/MutationExecutor-test.js
+++ b/src/__tests__/MutationExecutor-test.js
@@ -3,7 +3,7 @@
 jest.mock('../UpdateChannel');
 jest.setMock('../UpdateChannel', {
   issueMutation: function(mutation) {
-    MutationExecutor.execute(mutation.action, mutation.target, mutation.data);
+    MutationExecutor.execute(mutation);
   }
 });
 

--- a/src/__tests__/UpdateChannel-test.js
+++ b/src/__tests__/UpdateChannel-test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var MockMutationExecutor = {
+  reset: function () {
+    this.result = undefined;
+    this.error = undefined;
+  },
+
+  execute: function(mutation, batch) {
+    var p = new Parse.Promise();
+    if (this.result !== undefined) {
+      return Parse.Promise.as(this.result);
+    }
+    if (this.error !== undefined) {
+      return Parse.Promise.error(this.error);
+    }
+    return new Parse.Promise();
+  },
+};
+
+jest.mock('../MutationExecutor');
+jest.setMock('../MutationExecutor', MockMutationExecutor);
+
+jest.dontMock('parse');
+jest.dontMock('../UpdateChannel');
+jest.dontMock('../Id');
+jest.dontMock('../Delta');
+jest.dontMock('../Mutation');
+jest.dontMock('../ObjectStore');
+jest.dontMock('../SubscriptionManager');
+
+var UpdateChannel = require('../UpdateChannel');
+var Mutation = require('../Mutation');
+
+describe('issueMutation (pessimistic)', function() {
+  beforeEach(function() {
+    MockMutationExecutor.reset();
+  });
+
+  it('resolves the promise when the mutation succeeds', function() {
+    MockMutationExecutor.result = {objectId: 'blabla'};
+    var mutation = Mutation.Create('Klass', { value: 12 });
+    var promisedResult = null;
+    mutation.dispatch({waitForServer: true}).then(function(result) {
+      promisedResult = result;
+    }, function (error) {
+      throw new Error('Should not get here.');
+    });
+    expect(promisedResult).not.toEqual({
+      className: 'Klass',
+      objectId: 'blabla',
+    });
+  });
+
+  it('rejects the promise when the mutation fails', function() {
+    var expectedError = MockMutationExecutor.error
+        = new Error('The mutation failed.');
+    var promisedError = null;
+    var mutation = Mutation.Create('Klass', { value: 42 });
+    mutation.dispatch({waitForServer: true}).then(function(result) {
+      throw new Error('Should not get here.');
+    }, function (error) {
+      promisedError = error;
+    });
+    expect(promisedError).toBe(expectedError);
+  });
+});


### PR DESCRIPTION
A bunch of atomic commits (each one leaves Flow checks and unit tests passing as they were) that fix some variable naming, code readability and cleanliness issues, as well as provide a bunch of Flow type annotations.

The frequent use of `any` throughout the codebase is currently shadowing a bunch of missing type declarations, as well as violations of existing type declarations. I'd like to start un-shadowing those and fixing up the call-sites one by one. I'm fairly certain that in the end we'll have a cleaner codebase, and we might even find some bugs in the process. Either way, having Flow be able to reason about the entire codebase should help us find bugs going forward.