### PR TITLE
removed reference to /dist/ from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ ParseReact.Mutation.Create('Comment', {
 
 ## Getting Started
 
-You can download Parse + React from [within this Github repo](/dist/). It's
-also available [on our CDN](https://www.parsecdn.com/js/parse-react.js)
-([minified](https://www.parsecdn.com/js/parse-react.min.js)), and on
+Parse + React  is available from [our CDN](https://www.parsecdn.com/js/parse-react.js)
+([minified](https://www.parsecdn.com/js/parse-react.min.js)), and 
 [npm](https://www.npmjs.com/package/parse-react).
 
 If you're not familiar with React, we recommend you first walk through their


### PR DESCRIPTION
Per this issue: https://github.com/ParsePlatform/ParseReact/issues/114

It looks like the dist directory was added to .gitignore as of https://github.com/ParsePlatform/ParseReact/commit/da8297f59c44edea363bfa00b7df68e28c595b69