### PR TITLE
#117 Parse-React tries to flatten elements of array even if they're not Parse Objects

### DIFF
--- a/src/flatten.js
+++ b/src/flatten.js
@@ -34,7 +34,7 @@ function mappedFlatten(el) {
       objectId: el.id
     }
   }
-  return flatten(el);
+  return el;
 }
 
 /**


### PR DESCRIPTION
`mappedFlatten(el)` tried to flatten every element of the array (by calling `flatten(el)`) even if they are not Parse Objects, resulting in many **Attempted to flatten something that is not a Parse Object** warnings.